### PR TITLE
Added setCameraSpec()

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ sio = socketio.AsyncServer(cors_allowed_origins='*')
 app = web.Application()
 sio.attach(app)
 
-
 # Define a connection event
 @sio.event
 async def connect(sid, environ):
@@ -21,14 +20,22 @@ async def GET_NODE_DATA(sid):
 
 # Function to capture
 async def capture(data):
+    # Get current time
+    current_time = datetime.now()
+
     # Configure capture settings
     cam = setCaptureSpec(data,'STILL')
-    
-    capture_time = datetime.strptime(data["time"], "%a, %d %b %Y %H:%M:%S %Z")
+
+    # Determine Capture Time
+    if data["time"] is None:
+        capture_time = current_time
+    else:
+        capture_time = datetime.strptime(data["time"], "%a, %d %b %Y %H:%M:%S %Z")
+
     print(f"🟠 | Capturing image at {capture_time}")
     
     # Calculate sleep time
-    sleep_time = (capture_time - datetime.now()).total_seconds()
+    sleep_time = (capture_time - current_time).total_seconds()
     
     # Sleep until it's time to capture
     await asyncio.sleep(max(0, sleep_time))
@@ -57,9 +64,15 @@ async def CAPTURE_IMAGE(sid, data):
 # Stream event
 @sio.event
 async def START_STREAM(sid, data):
+    # Get current time
+    current_time = datetime.now()
 
     # Determine length of video stream
-    end_time = datetime.strptime(data["time"], "%a, %d %b %Y %H:%M:%S %Z")
+    if data["time"] is None:
+        end_time = current_time
+    else:
+        end_time = datetime.strptime(data["time"], "%a, %d %b %Y %H:%M:%S %Z")
+    
     print(f"🟠 | Starting video stream to end at {end_time}")
 
     # Configure video settings

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import asyncio
 from datetime import datetime
 from utils import *
 
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 
 # Create a new Socket.IO server with specified port
 sio = socketio.AsyncServer(cors_allowed_origins='*')
@@ -31,7 +31,6 @@ async def GET_NODE_DATA(sid):
 
 # Function to capture
 async def capture(data):
-    
     # Configure capture settings
     cam = setCaptureSpec(cam,data)
     

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import platform
 from aiohttp import web
 import asyncio
 from datetime import datetime
+from utils import *
 
 VERSION = "1.8.0"
 
@@ -13,10 +14,10 @@ sio = socketio.AsyncServer(cors_allowed_origins='*')
 app = web.Application()
 sio.attach(app)
 
-# Set up the camera
+# Initialise camera instance
 from picamera2 import Picamera2
 cam = Picamera2()
-cam.set_controls({"ExposureTime": 1000, "AnalogueGain": 1.0})
+
 
 # Define a connection event
 @sio.event
@@ -30,15 +31,13 @@ async def GET_NODE_DATA(sid):
 
 # Function to capture
 async def capture(data):
-    x = data["resolution"]["x"]
-    y = data["resolution"]["y"]
+    
+    # Configure capture settings
+    cam = setCaptureSpec(cam,data)
+    
     capture_time = datetime.strptime(data["time"], "%a, %d %b %Y %H:%M:%S %Z")
-
     print(f"🟠 | Capturing image at {capture_time}")
     
-    camera_config = cam.create_preview_configuration(main={"size": (x, y)})
-    cam.configure(camera_config)
-
     # Calculate sleep time
     sleep_time = (capture_time - datetime.now()).total_seconds()
     

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,9 @@ import asyncio
 from datetime import datetime
 from picamera2 import Picamera2
 
+# Initialise camera instance
+cam = Picamera2()
+
 def setCaptureSpec(data,capture_mode):
     # Set default values
     x = 1920
@@ -13,9 +16,6 @@ def setCaptureSpec(data,capture_mode):
     iso = 100
     shutterSpeed = 1000 
     
-    # Initialise camera instance
-    cam = Picamera2()
-
     # Store camera settings if specified 
     if 'resolution' in data:
         resolution = data["resolution"]

--- a/utils.py
+++ b/utils.py
@@ -15,9 +15,6 @@ def setCaptureSpec(data,capture_mode):
     y = 1080
     iso = 100
     shutterSpeed = 1000 
-
-    print(data)
-    print(x, y, iso, shutterSpeed)
     
     # Store camera settings if specified 
     if 'resolution' in data:

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,9 @@ def setCaptureSpec(data,capture_mode):
     y = 1080
     iso = 100
     shutterSpeed = 1000 
+
+    print(data)
+    print(x, y, iso, shutterSpeed)
     
     # Store camera settings if specified 
     if 'resolution' in data:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,31 @@
+# Set default values
+x = 1920
+y = 1080
+iso = 100
+shutterSpeed = 1000 
+
+def setCaptureSpec(cam,data):
+
+    # Set resolution if specified
+    if 'resolution' in data:
+        resolution = data["resolution"]
+        if 'x' in resolution and 'y' in resolution:
+            x = resolution["x"]
+            y = resolution["y"]
+
+    # Set iso if specified
+    if 'iso' in data:
+        if data["iso"]:
+            iso = data["iso"]
+        
+    # Set shutter speed if specified
+    if 'shutter_speed' in data:
+        if data["shutter_speed"]:
+            shutterSpeed = data["shutter_speed"]
+
+    # Apply settings
+    camera_config = cam.create_still_configuration(main={"size": (x, y)})
+    cam.set_controls({"ExposureTime": shutterSpeed, "AnalogueGain": round(iso / 100,1)})
+
+    cam.configure(camera_config)
+    return cam

--- a/utils.py
+++ b/utils.py
@@ -22,16 +22,16 @@ def setCaptureSpec(data,capture_mode):
     # Store camera settings if specified 
     if 'resolution' in data:
         resolution = data["resolution"]
-        if 'x' in resolution and 'y' in resolution:
+        if resolution['x'] is not None and resolution['y'] is not None:
             x = resolution["x"]
             y = resolution["y"]
 
     if 'iso' in data:
-        if data["iso"]:
+        if data["iso"] is not None:
             iso = data["iso"]
             
     if 'shutter_speed' in data:
-        if data["shutter_speed"]:
+        if data["shutter_speed"] is not None:
             shutterSpeed = data["shutter_speed"]
 
     # Determine capture mode

--- a/utils.py
+++ b/utils.py
@@ -49,5 +49,4 @@ def setCaptureSpec(data,capture_mode):
     print(f"🟠 | Resolution set to {x}x{y} | Iso set to {iso} | Shutter speed set to {shutterSpeed} ")  
 
     
-
     return cam

--- a/utils.py
+++ b/utils.py
@@ -1,31 +1,53 @@
+import time
+import socketio
+import platform
+from aiohttp import web
+import asyncio
+from datetime import datetime
+from picamera2 import Picamera2
+
 # Set default values
 x = 1920
 y = 1080
 iso = 100
 shutterSpeed = 1000 
 
-def setCaptureSpec(cam,data):
+def setCaptureSpec(data,capture_mode):
 
-    # Set resolution if specified
+    # Initialise camera instance
+    cam = Picamera2()
+
+    # Store camera settings if specified 
     if 'resolution' in data:
         resolution = data["resolution"]
         if 'x' in resolution and 'y' in resolution:
             x = resolution["x"]
             y = resolution["y"]
 
-    # Set iso if specified
     if 'iso' in data:
         if data["iso"]:
             iso = data["iso"]
-        
-    # Set shutter speed if specified
+            
     if 'shutter_speed' in data:
         if data["shutter_speed"]:
             shutterSpeed = data["shutter_speed"]
+     
+
+    # Determine capture mode
+    if capture_mode == 'STILL':
+        camera_config = cam.create_still_configuration(main={"size": (x, y)})
+        print(f"🟠 | Camera configured for still capture") 
+
+    if capture_mode == 'STREAM':
+        camera_config = cam.create_preview_configuration(main={"size": (x, y)})
+        print(f"🟠 | Camera configured for video stream") 
+
 
     # Apply settings
-    camera_config = cam.create_still_configuration(main={"size": (x, y)})
     cam.set_controls({"ExposureTime": shutterSpeed, "AnalogueGain": round(iso / 100,1)})
-
     cam.configure(camera_config)
+    print(f"🟠 | Resolution set to {x}x{y} | Iso set to {iso} | Shutter speed set to {shutterSpeed} ")  
+
+    
+
     return cam

--- a/utils.py
+++ b/utils.py
@@ -6,14 +6,13 @@ import asyncio
 from datetime import datetime
 from picamera2 import Picamera2
 
-# Set default values
-x = 1920
-y = 1080
-iso = 100
-shutterSpeed = 1000 
-
 def setCaptureSpec(data,capture_mode):
-
+    # Set default values
+    x = 1920
+    y = 1080
+    iso = 100
+    shutterSpeed = 1000 
+    
     # Initialise camera instance
     cam = Picamera2()
 
@@ -31,7 +30,6 @@ def setCaptureSpec(data,capture_mode):
     if 'shutter_speed' in data:
         if data["shutter_speed"]:
             shutterSpeed = data["shutter_speed"]
-     
 
     # Determine capture mode
     if capture_mode == 'STILL':
@@ -42,11 +40,9 @@ def setCaptureSpec(data,capture_mode):
         camera_config = cam.create_preview_configuration(main={"size": (x, y)})
         print(f"🟠 | Camera configured for video stream") 
 
-
     # Apply settings
     cam.set_controls({"ExposureTime": shutterSpeed, "AnalogueGain": round(iso / 100,1)})
     cam.configure(camera_config)
     print(f"🟠 | Resolution set to {x}x{y} | Iso set to {iso} | Shutter speed set to {shutterSpeed} ")  
 
-    
     return cam


### PR DESCRIPTION
Default values declared at the top, method takes json data as argument then checks if res,iso and shutterspeed have been specified, if they have over write the default values, if not continue.

BTWA will need to be altered to send 'iso' and 'shutter_speed' along with 'resolution'.

Apparently you can't directly set iso settings on PiCamera2 so round(100 / 100,1) converts to AnalogueGain 1.0